### PR TITLE
Add piqc (open source) and Paralleliq (commercial) — GPU FinOps tools for AI infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@
 ### Open Source Tools
 
 - [Cloud Custodian](https://cloudcustodian.io/) - Stateless rules engine for policy definition and enforcement, with metrics, structured outputs and detailed reporting for clouds infrastructure.
+- [piqc](https://github.com/paralleliq/piqc) - Open-source GPU waste scanner for Kubernetes inference clusters. Detects tier misplacement, idle capacity, OOM risk, and CPU:GPU imbalance — quantified in dollars.
 
 ### Commercial Tools
 
@@ -58,6 +59,7 @@
 - [CloudCheckr](https://www.cloudhealthtech.com/)
 - [CloudHealth](https://www.cloudhealthtech.com/)
 - [Densify](https://www.densify.com/)
+- [Paralleliq](https://www.paralleliq.ai) - Model-aware GPU control plane for AI infrastructure. Detects GPU waste, quantifies cost impact, and delivers actionable recommendations with approval workflows.
 
 ## Job Postings
 


### PR DESCRIPTION
As AI infrastructure spend becomes a major line item, GPU FinOps is an emerging discipline that fits squarely within cloud financial management. This PR adds two complementary tools:

### Open Source Tools

**[piqc](https://github.com/paralleliq/piqc)** — read-only GPU waste scanner for Kubernetes inference clusters. Deploys as a Kubernetes Job, requires no write permissions, and surfaces four waste patterns that typically account for 20–40% of GPU spend:
- Tier misplacement (model on a GPU with more memory/compute than needed)
- Dark capacity (GPU allocated but serving no live traffic)
- OOM risk (model approaching GPU memory ceiling)
- CPU:GPU imbalance (CPU saturation throttling GPU throughput)

### Commercial Tools

**[Paralleliq](https://www.paralleliq.ai)** — model-aware GPU control plane for AI infrastructure. Unlike generic cloud cost tools that see only hardware utilization, Paralleliq understands which model is running on which GPU, what tier it belongs on, and what the cost delta is between where it is and where it should be. Delivers recommendations with human-in-the-loop approval workflows and a full audit trail.

Both are focused on the FinOps problem of GPU spend visibility and optimization for teams running AI workloads at scale.